### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/postfix-relay-operator/tests/integration/conftest.py
+++ b/postfix-relay-operator/tests/integration/conftest.py
@@ -29,15 +29,12 @@ def deploy_postfix_relay_fixture(
     postfix_relay_app_name = "postfix-relay"
 
     if not juju.status().apps.get(postfix_relay_app_name):
-        juju.deploy(
-            f"./{postfix_relay_charm}",
-            postfix_relay_app_name,
-        )
+        juju.deploy(f"./{postfix_relay_charm}", postfix_relay_app_name, log=False)
 
     # Ensure self-signed-certificates is deployed, but make the operation idempotent.
     if not juju.status().apps.get("self-signed-certificates"):
         try:
-            juju.deploy("self-signed-certificates")
+            juju.deploy("self-signed-certificates", log=False)
         except Exception as exc:
             # Ignore benign "already exists" style errors; re-raise anything else.
             if "already exists" not in str(exc):

--- a/postfix-relay-operator/tests/integration/test_charm.py
+++ b/postfix-relay-operator/tests/integration/test_charm.py
@@ -56,9 +56,9 @@ def test_simple_relay(juju: jubilant.Juju, postfix_relay_app, machine_ip_address
     command_to_put_domain = (
         f"echo {machine_ip_address} testrelay.internal | sudo tee -a /etc/hosts"
     )
-    juju.exec(machine=unit.machine, command=command_to_put_domain)
+    juju.exec(machine=unit.machine, command=command_to_put_domain, log=False)
 
-    juju.config(postfix_relay_app, {"relay_domains": "- testrelay.internal"})
+    juju.config(postfix_relay_app, {"relay_domains": "- testrelay.internal"}, log=False)
     juju.wait(
         lambda status: status.apps[postfix_relay_app].is_active,
         error=jubilant.any_blocked,
@@ -112,6 +112,7 @@ def test_authentication(juju: jubilant.Juju, postfix_relay_app, machine_ip_addre
             "relay_host": f"[{machine_ip_address}]",
             "enable_reject_unknown_sender_domain": "false",
         },
+        log=False,
     )
 
     juju.wait(


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.