### PR TITLE
chore(convert-to-jubilant): migrate integration tests to jubilant (charmkeeper)

### DIFF
--- a/postfix-relay-configurator-operator/tox.ini
+++ b/postfix-relay-configurator-operator/tox.ini
@@ -43,14 +43,13 @@ deps =
     flake8-docstrings-complete
     flake8-test-docs
     isort
+    jubilant ~= 1.8
     mypy
     pep8-naming
     pydocstyle>=2.10
     pylint
     pyproject-flake8
     pytest
-    pytest-asyncio
-    pytest-operator
     requests
     types-PyYAML
     types-requests
@@ -104,10 +103,7 @@ deps =
     -r{toxinidir}/requirements.txt
     allure-pytest>=2.8.18
     git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
-    jubilant == 1.4.0
-    juju==3.6.*
+    jubilant ~= 1.8
     pytest
-    pytest-asyncio
-    pytest-operator
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/postfix-relay-operator/tests/conftest.py
+++ b/postfix-relay-operator/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm tests."""
@@ -11,3 +11,13 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="store", help="Charm file to be deployed")
+    parser.addoption("--model", action="store", default=None, help="Juju model to use")
+    parser.addoption(
+        "--keep-models", action="store_true", default=False, help="Keep models after tests"
+    )
+    parser.addoption(
+        "--use-existing",
+        action="store_true",
+        default=False,
+        help="Use existing Juju controller/model",
+    )

--- a/postfix-relay-operator/tests/integration/test_charm.py
+++ b/postfix-relay-operator/tests/integration/test_charm.py
@@ -56,7 +56,7 @@ def test_simple_relay(juju: jubilant.Juju, postfix_relay_app, machine_ip_address
     command_to_put_domain = (
         f"echo {machine_ip_address} testrelay.internal | sudo tee -a /etc/hosts"
     )
-    juju.exec(machine=unit.machine, command=command_to_put_domain)
+    juju.exec(command_to_put_domain, machine=unit.machine)
 
     juju.config(postfix_relay_app, {"relay_domains": "- testrelay.internal"})
     juju.wait(

--- a/postfix-relay-operator/tox.ini
+++ b/postfix-relay-operator/tox.ini
@@ -43,14 +43,13 @@ deps =
     flake8-docstrings-complete
     flake8-test-docs
     isort
+    jubilant ~= 1.8
     mypy
     pep8-naming
     pydocstyle>=2.10
     pylint
     pyproject-flake8
     pytest
-    pytest-asyncio
-    pytest-operator
     requests
     types-PyYAML
     types-requests
@@ -104,9 +103,7 @@ deps =
     -r{toxinidir}/requirements.txt
     allure-pytest>=2.8.18
     git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
-    jubilant == 1.4.0
-    juju==3.6
+    jubilant ~= 1.8
     pytest
-    pytest-operator
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Summary

This PR migrates the integration tests for `postfix-relay-operator` from `pytest-operator`/`python-libjuju` to the synchronous `jubilant` library, aligning with current team standards.

### Changes

#### `postfix-relay-operator/tests/integration/test_charm.py`
- Fixed `juju.exec()` call: `command` is positional in jubilant's API — changed `juju.exec(machine=unit.machine, command=cmd)` → `juju.exec(cmd, machine=unit.machine)`.

#### `postfix-relay-operator/tests/conftest.py`
- Added `--model`, `--keep-models`, `--use-existing` pytest CLI options required by the session-scoped `juju` fixture.

#### `postfix-relay-operator/tox.ini`
- Replaced `pytest-asyncio`, `pytest-operator`, `juju==3.6` with `jubilant ~= 1.8`.

#### `postfix-relay-configurator-operator/tox.ini`
- Replaced `pytest-asyncio`, `pytest-operator`, `juju==3.6.*` with `jubilant ~= 1.8`.

---
_This PR was created by [charmkeeper](https://github.com/canonical/charmkeeper)._