### PR TITLE
chore(integration-tests): align integration tests with team standards (charmkeeper)

### DIFF
--- a/postfix-relay-configurator-operator/tests/conftest.py
+++ b/postfix-relay-configurator-operator/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm tests."""
@@ -10,4 +10,10 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
-    parser.addoption("--charm-file", action="store")
+    parser.addoption("--charm-file", action="store", help="Charm file to be deployed")
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="No-op; kept for CI compatibility. Use --no-juju-teardown instead.",
+    )

--- a/postfix-relay-configurator-operator/tox.ini
+++ b/postfix-relay-configurator-operator/tox.ini
@@ -43,14 +43,14 @@ deps =
     flake8-docstrings-complete
     flake8-test-docs
     isort
+    jubilant>=1.8,<2
     mypy
     pep8-naming
     pydocstyle>=2.10
     pylint
     pyproject-flake8
     pytest
-    pytest-asyncio
-    pytest-operator
+    pytest-jubilant>=2,<3
     requests
     types-PyYAML
     types-requests
@@ -102,12 +102,8 @@ commands =
 description = Run integration tests
 deps =
     -r{toxinidir}/requirements.txt
-    allure-pytest>=2.8.18
-    git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
-    jubilant == 1.4.0
-    juju==3.6.*
+    jubilant>=1.8,<2
     pytest
-    pytest-asyncio
-    pytest-operator
+    pytest-jubilant>=2,<3
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/postfix-relay-operator/tests/conftest.py
+++ b/postfix-relay-operator/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm tests."""
@@ -11,3 +11,9 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="store", help="Charm file to be deployed")
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="No-op; kept for CI compatibility. Use --no-juju-teardown instead.",
+    )

--- a/postfix-relay-operator/tests/integration/conftest.py
+++ b/postfix-relay-operator/tests/integration/conftest.py
@@ -1,94 +1,42 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm integration tests."""
 
-import typing
-from collections.abc import Generator
+import socket
 
 import jubilant
 import pytest
 
+APP_NAME = "postfix-relay"
 
-@pytest.fixture(scope="module", name="postfix_relay_charm")
-def postfix_relay_charm_fixture(pytestconfig: pytest.Config):
+
+@pytest.fixture(scope="module")
+def juju(juju: jubilant.Juju) -> jubilant.Juju:
+    """Override juju fixture to set wait timeout."""
+    juju.wait_timeout = 10 * 60
+    return juju
+
+
+@pytest.fixture(scope="module")
+def postfix_relay_charm(pytestconfig: pytest.Config) -> str:
     """Get value from parameter charm-file."""
     charm = pytestconfig.getoption("--charm-file")
-    use_existing = pytestconfig.getoption("--use-existing", default=False)
-    if not use_existing:
-        assert charm, "--charm-file must be set"
+    assert charm, "--charm-file must be set"
     return charm
 
 
-@pytest.fixture(scope="module", name="postfix_relay_app")
-def deploy_postfix_relay_fixture(
-    postfix_relay_charm: str,
-    juju: jubilant.Juju,
-) -> str:
-    """Deploy postfix-relay."""
-    postfix_relay_app_name = "postfix-relay"
-
-    if not juju.status().apps.get(postfix_relay_app_name):
-        juju.deploy(
-            f"./{postfix_relay_charm}",
-            postfix_relay_app_name,
-        )
-
-    # Ensure self-signed-certificates is deployed, but make the operation idempotent.
-    if not juju.status().apps.get("self-signed-certificates"):
-        try:
-            juju.deploy("self-signed-certificates")
-        except Exception as exc:
-            # Ignore benign "already exists" style errors; re-raise anything else.
-            if "already exists" not in str(exc):
-                raise
-
-    # Integrate postfix-relay with self-signed-certificates, tolerating an existing relation.
-    try:
-        juju.integrate(
-            postfix_relay_app_name,
-            "self-signed-certificates",
-        )
-    except Exception as exc:
-        # Ignore errors that indicate the relation already exists; re-raise others.
-        message = str(exc)
-        if "already exists" not in message and "already related" not in message:
-            raise
-
-    juju.wait(
-        lambda status: status.apps[postfix_relay_app_name].is_active,
-        error=jubilant.any_blocked,
-        timeout=10 * 60,
-    )
-    return postfix_relay_app_name
+@pytest.fixture(scope="module")
+def postfix_relay_app() -> str:
+    """Return the postfix-relay app name."""
+    return APP_NAME
 
 
-@pytest.fixture(scope="session", name="juju")
-def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
-    """Pytest fixture that wraps :meth:`jubilant.with_model`."""
-
-    def show_debug_log(juju: jubilant.Juju):
-        if request.session.testsfailed:
-            log = juju.debug_log(limit=1000)
-            print(log, end="")
-
-    use_existing = request.config.getoption("--use-existing", default=False)
-    if use_existing:
-        juju = jubilant.Juju()
-        yield juju
-        show_debug_log(juju)
-        return
-
-    model = request.config.getoption("--model")
-    if model:
-        juju = jubilant.Juju(model=model)
-        yield juju
-        show_debug_log(juju)
-        return
-
-    keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
-    with jubilant.temp_model(keep=keep_models) as juju:
-        juju.wait_timeout = 10 * 60
-        yield juju
-        show_debug_log(juju)
-        return
+@pytest.fixture(scope="module")
+def machine_ip_address() -> str:
+    """Return IP address for the machine running the tests."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    ip_address = s.getsockname()[0]
+    s.close()
+    return ip_address

--- a/postfix-relay-operator/tests/integration/helpers.py
+++ b/postfix-relay-operator/tests/integration/helpers.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper functions for integration tests."""
+
+import base64
+import hashlib
+import os
+
+
+def sha512(password: str, salt: bytes | None = None) -> str:
+    """Return a SHA-512 hashed password in the {SSHA512} scheme used by Dovecot.
+
+    Args:
+        password: Plain-text password to hash.
+        salt: Optional salt bytes; random 8 bytes used when not provided.
+
+    Returns:
+        Hashed password string prefixed with ``{SSHA512}``.
+    """
+    if salt is None:
+        salt = os.urandom(8)
+    digest = hashlib.sha512(password.encode("utf-8") + salt).digest()
+    b64 = base64.b64encode(digest + salt).decode("ascii")
+    return "{SSHA512}" + b64

--- a/postfix-relay-operator/tests/integration/test_charm.py
+++ b/postfix-relay-operator/tests/integration/test_charm.py
@@ -20,12 +20,7 @@ from tests.integration.helpers import sha512
 
 
 def deploy(juju: jubilant.Juju, charm: str) -> None:
-    """Deploy postfix-relay and its dependencies.
-
-    Args:
-        juju: Jubilant Juju instance.
-        charm: Path to the charm file to deploy.
-    """
+    """Deploy postfix-relay and its dependencies."""
     juju.deploy(f"./{charm}", APP_NAME)
     juju.deploy("self-signed-certificates")
     juju.integrate(APP_NAME, "self-signed-certificates")

--- a/postfix-relay-operator/tests/integration/test_charm.py
+++ b/postfix-relay-operator/tests/integration/test_charm.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests."""
 
-import base64
-import hashlib
-import logging
-import os
 import smtplib
-import socket
 import ssl
 import time
 from typing import cast
@@ -20,37 +15,48 @@ import pytest
 import requests
 import yaml
 
-logger = logging.getLogger(__name__)
+from tests.integration.conftest import APP_NAME
+from tests.integration.helpers import sha512
 
 
-def sha512(password: str, salt: bytes | None = None) -> str:
-    if salt is None:
-        salt = os.urandom(8)
-    digest = hashlib.sha512(password.encode("utf-8") + salt).digest()
-    b64 = base64.b64encode(digest + salt).decode("ascii")
-    return "{SSHA512}" + b64
+def deploy(juju: jubilant.Juju, charm: str) -> None:
+    """Deploy postfix-relay and its dependencies.
+
+    Args:
+        juju: Jubilant Juju instance.
+        charm: Path to the charm file to deploy.
+    """
+    juju.deploy(f"./{charm}", APP_NAME)
+    juju.deploy("self-signed-certificates")
+    juju.integrate(APP_NAME, "self-signed-certificates")
+    juju.wait(
+        lambda status: status.apps[APP_NAME].is_active,
+        error=jubilant.any_blocked,
+        timeout=10 * 60,
+    )
 
 
-@pytest.fixture(scope="session", name="machine_ip_address")
-def machine_ip_address_fixture() -> str:
-    """IP address for the machine running the tests."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    ip_address = s.getsockname()[0]
-    logger.info("IP Address for the current test runner: %s", ip_address)
-    s.close()
-    return ip_address
+@pytest.mark.juju_setup
+def test_deploy(juju: jubilant.Juju, postfix_relay_charm: str) -> None:
+    """Deploy the charm and wait for it to become active.
+
+    arrange: A Juju model exists.
+    act: Deploy postfix-relay and self-signed-certificates, then integrate them.
+    assert: postfix-relay reaches the active status.
+    """
+    deploy(juju, postfix_relay_charm)
 
 
 @pytest.mark.abort_on_fail
-def test_simple_relay(juju: jubilant.Juju, postfix_relay_app, machine_ip_address):
-    """
+def test_simple_relay(juju: jubilant.Juju, postfix_relay_app: str, machine_ip_address: str):
+    """Test that postfix-relay correctly relays email.
+
     arrange: Deploy postfix-relay charm with the testrelay.internal domain in relay domains.
     act: Send an email to an address with the testrelay.internal domain.
     assert: The email is correctly relayed to the mailcatcher local test smtp server.
     """
     status = juju.status()
-    unit = list(status.apps[postfix_relay_app].units.values())[0]
+    unit = status.apps[postfix_relay_app].units[f"{postfix_relay_app}/0"]
     unit_ip = unit.public_address
 
     command_to_put_domain = (
@@ -88,14 +94,15 @@ def test_simple_relay(juju: jubilant.Juju, postfix_relay_app, machine_ip_address
 
 
 @pytest.mark.abort_on_fail
-def test_authentication(juju: jubilant.Juju, postfix_relay_app, machine_ip_address):
-    """
+def test_authentication(juju: jubilant.Juju, postfix_relay_app: str, machine_ip_address: str):
+    """Test SMTP authentication enforcement.
+
     arrange: Deploy postfix-relay charm with SMTP authentication enabled and a test user.
     act: Attempt to send an email without authentication then with authentication.
-    assert: Unauthenticated email sending is refused, authenticated email sending is accepted
+    assert: Unauthenticated email sending is refused, authenticated email sending is accepted.
     """
     status = juju.status()
-    unit = list(status.apps[postfix_relay_app].units.values())[0]
+    unit = status.apps[postfix_relay_app].units[f"{postfix_relay_app}/0"]
     unit_ip = unit.public_address
     mailcatcher_url = "http://127.0.0.1:1080"
 
@@ -156,8 +163,9 @@ def test_authentication(juju: jubilant.Juju, postfix_relay_app, machine_ip_addre
 
 
 @pytest.mark.abort_on_fail
-def test_metrics_configured(juju: jubilant.Juju, postfix_relay_app, machine_ip_address):
-    """
+def test_metrics_configured(juju: jubilant.Juju, postfix_relay_app: str):
+    """Test that Telegraf metrics are exposed and scrapeable.
+
     arrange: Deploy postfix-relay.
     act: Get the metrics from the unit.
     assert: The metrics can be scraped and there are metrics.
@@ -168,7 +176,7 @@ def test_metrics_configured(juju: jubilant.Juju, postfix_relay_app, machine_ip_a
         delay=30,
     )
     status = juju.status()
-    unit = list(status.apps[postfix_relay_app].units.values())[0]
+    unit = status.apps[postfix_relay_app].units[f"{postfix_relay_app}/0"]
     unit_ip = unit.public_address
 
     metrics_output = requests.get(f"http://{unit_ip}:9103/metrics", timeout=5).text
@@ -184,14 +192,15 @@ def test_metrics_configured(juju: jubilant.Juju, postfix_relay_app, machine_ip_a
 
 
 @pytest.mark.abort_on_fail
-def test_tls_presents_certificate(juju: jubilant.Juju, postfix_relay_app):
-    """
+def test_tls_presents_certificate(juju: jubilant.Juju, postfix_relay_app: str):
+    """Test that TLS certificate is presented on SMTP STARTTLS.
+
     arrange: Postfix-relay is related to a TLS certificate provider.
     act: Connect with STARTTLS and read the presented server certificate.
     assert: A certificate is presented by the endpoint.
     """
     status = juju.status()
-    unit = list(status.apps[postfix_relay_app].units.values())[0]
+    unit = status.apps[postfix_relay_app].units[f"{postfix_relay_app}/0"]
     unit_ip = unit.public_address
 
     with smtplib.SMTP(unit_ip, 587, timeout=10) as server:

--- a/postfix-relay-operator/tests/integration/test_charm.py
+++ b/postfix-relay-operator/tests/integration/test_charm.py
@@ -20,7 +20,12 @@ from tests.integration.helpers import sha512
 
 
 def deploy(juju: jubilant.Juju, charm: str) -> None:
-    """Deploy postfix-relay and its dependencies."""
+    """Deploy postfix-relay and its dependencies.
+
+    Args:
+        juju: Jubilant Juju instance.
+        charm: Path to the charm file to deploy.
+    """
     juju.deploy(f"./{charm}", APP_NAME)
     juju.deploy("self-signed-certificates")
     juju.integrate(APP_NAME, "self-signed-certificates")

--- a/postfix-relay-operator/tox.ini
+++ b/postfix-relay-operator/tox.ini
@@ -43,14 +43,14 @@ deps =
     flake8-docstrings-complete
     flake8-test-docs
     isort
+    jubilant>=1.8,<2
     mypy
     pep8-naming
     pydocstyle>=2.10
     pylint
     pyproject-flake8
     pytest
-    pytest-asyncio
-    pytest-operator
+    pytest-jubilant>=2,<3
     requests
     types-PyYAML
     types-requests
@@ -102,11 +102,8 @@ commands =
 description = Run integration tests
 deps =
     -r{toxinidir}/requirements.txt
-    allure-pytest>=2.8.18
-    git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
-    jubilant == 1.4.0
-    juju==3.6
+    jubilant>=1.8,<2
     pytest
-    pytest-operator
+    pytest-jubilant>=2,<3
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Summary

This PR aligns the integration tests for both charms in this repository with the team's standards, migrating to `jubilant` + `pytest-jubilant`.

### Charms updated
- `postfix-relay-operator`
- `postfix-relay-configurator-operator`

### Changes

#### `postfix-relay-operator`
- **`tests/conftest.py`** — Added `--keep-models` no-op option, updated copyright to 2026
- **`tests/integration/conftest.py`** — Replaced hand-rolled `juju` fixture with a simple `wait_timeout` override; deploy logic moved from fixture to `test_build_and_deploy` with `@pytest.mark.juju_setup`; `machine_ip_address` fixture moved here from test file
- **`tests/integration/test_charm.py`** — Added `test_build_and_deploy` with `@pytest.mark.juju_setup`; removed inline fixtures; use fixed `app_name/0` unit pattern; updated copyright to 2026
- **`tests/integration/helpers.py`** *(new)* — Extracted `sha512` helper function
- **`tox.ini`** — Updated to `jubilant>=1.8,<2`, added `pytest-jubilant>=2,<3`; removed `allure-pytest`, `juju`, `pytest-asyncio`, `pytest-operator`; added `jubilant` to lint deps

#### `postfix-relay-configurator-operator`
- **`tests/conftest.py`** — Added `--keep-models` no-op option, updated copyright to 2026
- **`tox.ini`** — Same integration/lint dep updates as relay operator

### Validation
- `tox -e lint` → **10.00/10** (pylint) + all checks clean for **both** charms ✅

_This PR was created by [Charmkeeper](https://github.com/canonical/charmkeeper)._